### PR TITLE
arm64用のイメージをビルドしないようにした

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -37,7 +37,6 @@ traefik:
     certificatesResolvers.letsencrypt.acme.httpchallenge: true
     certificatesResolvers.letsencrypt.acme.httpchallenge.entrypoint: web
 
-# Configure a custom healthcheck (default is /up on port 3000)
-# healthcheck:
-#   path: /healthz
-#   port: 4000
+builder:
+  multiarch: false
+


### PR DESCRIPTION
デプロイ先はamd64向けなので、arm64用のイメージを作る時間が無駄。

ref: https://github.com/mrsked/mrsk#using-native-builder-when-multi-arch-isnt-needed

`multiarch: false`にするとビルドするホストのarchでビルドする。ローカルでmrsk deployしたいときに困るけど、他にうまい設定はなさそうだったのと、GitHub Actionsでビルドする以外の状況は基本ないと思うのでいったんこれで。
