### PR TITLE
Fix warning from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 ARG RUBY_VERSION=3.4.1
-FROM ruby:$RUBY_VERSION as base
+FROM ruby:$RUBY_VERSION AS base
 
 WORKDIR /willnet_in
 


### PR DESCRIPTION
```
 DEBUG [51f5b3e1] 	 1 warning found (use docker --debug to expand):
 DEBUG [51f5b3e1] 	 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)
 ```
