### PR TITLE
デプロイ時のタイムアウトを伸ばした

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -8,6 +8,7 @@ proxy:
 servers:
   - 139.59.254.11
 
+deploy_timeout: 60
 
 registry:
   username: willnet


### PR DESCRIPTION
ログを見た感じ、puma起動前にコンテナ立ち上がってない判定になっていそう