### PR TITLE
slim版のDockerイメージを使う

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 ARG RUBY_VERSION=3.4.2
-FROM ruby:$RUBY_VERSION AS base
+FROM ruby:${RUBY_VERSION}-slim AS base
 
 WORKDIR /willnet_in
 


### PR DESCRIPTION
通常のDockerHub公式Rubyイメージはおよそ1GBあり大きすぎるので、200MB弱のslim版を利用する