### PR TITLE
loggerのバージョン不一致による例外を多分修正した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+gem 'aws_lambda_ric'
 gem 'lamby'
 gem 'sinatra'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aws_lambda_ric (3.2.0)
+      logger (>= 1.4, < 2.0)
     base64 (0.3.0)
     lambda-console-ruby (1.0.0)
     lamby (6.0.1)
@@ -32,9 +34,11 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
+  aws_lambda_ric
   lamby
   puma
   sinatra


### PR DESCRIPTION
リダイレクタが502になる。ログを見た限り、AWS Lambda RICが標準ライブラリのロガーを使っており、その後にbundle exec経由で実行したSinatraがloggerをrequireし、それぞれのバージョンが違うことで失敗していた。AWS Lambda RICをbundler配下に管理することで、この問題を解決できるのではないかと考えている。
